### PR TITLE
Change source import for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,18 +5,21 @@ repos:
   - id: black
     args:
       - --line-length=100
+
 - repo: https://github.com/asottile/reorder_python_imports
   rev: v2.7.1
   hooks:
   - id: reorder-python-imports
     args: ["--py37-plus"]
-- repo: https://gitlab.com/PyCQA/flake8
-  rev: 3.9.2
+
+- repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     args:
       - --max-line-length=100
     exclude: tests/test_table_writer.py
+
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
   hooks:


### PR DESCRIPTION
As title says. This is the recommended source for flake8 for PyAnsys libraries.